### PR TITLE
Removes `CoomandBlock`.

### DIFF
--- a/Tests/FlatUtilTests/CommandLineTests.swift
+++ b/Tests/FlatUtilTests/CommandLineTests.swift
@@ -5,41 +5,43 @@ import XCTest
 class CommandlineTests: XCTestCase {
 
     func testEmptyArgument() {
-        let cmd = Commandline(description: "") { _ in }
-        let pr = cmd.parse([])
+        let cmd = Commandline(description: "")
+        let pr = cmd.parse(arguments: [])
         XCTAssertNotNil(pr)
-        let (params, opts) = pr!
+        let (cmds, params, opts) = pr!
+        XCTAssert(cmds.isEmpty)
         XCTAssert(params.isEmpty)
         XCTAssert(opts.isEmpty)
     }
 
     func testCommandWithEmptyArgument() {
-        let cmd = Commandline(description: "") { _ in }
-        let (params, opts) = cmd.parse(["help"])!
+        let cmd = Commandline(description: "")
+        let (cmds, params, opts) = cmd.parse(arguments: ["prog", "help"])!
+        XCTAssert(cmds.isEmpty)
         XCTAssertEqual(params.first!, "help")
         XCTAssert(opts.isEmpty)
     }
 
     func testShortFlagOption() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         cmd.define(flagOption: "verbose", shortName: "v", description: "Show more details.")
         cmd.define(flagOption: "useMagic", shortName: "m", description: "Set to use magic.")
 
-        let (params, opts) = cmd.parse(["-v", "/tmp/a.txt"])!
+        let (_, params, opts) = cmd.parse(arguments: ["prog", "-v", "/tmp/a.txt"])!
         XCTAssertEqual(params.count, 1)
         XCTAssertEqual(params.first!, "/tmp/a.txt")
         XCTAssertEqual(opts.count, 2)
         XCTAssert(opts.has(flag: "verbose"))
         XCTAssertFalse(opts.has(flag: "useMagic"))
 
-        let (p1, o1) = cmd.parse(["-m", "-v", "", ""])!
+        let (_, p1, o1) = cmd.parse(arguments: ["prog", "-m", "-v", "", ""])!
         XCTAssertEqual(p1.count, 2)
         XCTAssertEqual(p1.first!, "")
         XCTAssertEqual(o1.count, 2)
         XCTAssert(o1.has(flag: "useMagic"))
         XCTAssert(o1.has(flag: "verbose"))
 
-        let (p2, o2) = cmd.parse(["-vm"])!
+        let (_, p2, o2) = cmd.parse(arguments: ["prog", "-vm"])!
         XCTAssertEqual(p2.count, 0)
         XCTAssertEqual(o2.count, 2)
         XCTAssert(o2.has(flag: "usemagic"))
@@ -47,7 +49,7 @@ class CommandlineTests: XCTestCase {
     }
 
     func testShortValueOption() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         let str_validator: (String) throws -> String = { str in
             return str
         }
@@ -65,12 +67,12 @@ class CommandlineTests: XCTestCase {
             validator: str_validator)
         cmd.define(flagOption: "verbose", shortName: "v", description: "")
 
-        let (p0, o0) = cmd.parse([])!
+        let (_, p0, o0) = cmd.parse(arguments: [])!
         XCTAssert(p0.isEmpty)
         XCTAssertEqual(o0.count, 3)
         XCTAssertFalse(o0.has(flag: "verbose"))
 
-        let (_, o1) = cmd.parse(["-i", "20", "-va", "30"])!
+        let (_, _, o1) = cmd.parse(arguments: ["prog", "-i", "20", "-va", "30"])!
         XCTAssertEqual(o1.count, 3)
         XCTAssert(o1.has(flag: "verbose"))
         let min_user_count: String? = o1.valueOf(option: "min-user-count")
@@ -82,33 +84,33 @@ class CommandlineTests: XCTestCase {
     }
 
     func testAllowEmptyShortName() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         cmd.define(flagOption: "npm", shortName: "", description: "install npm or not.")
         cmd.define(flagOption: "opencl", shortName: "", description: "")
 
-        let (_, o) = cmd.parse(["--no-npm", "--opencl", "rest"])!
+        let (_, _, o) = cmd.parse(arguments: ["prog", "--no-npm", "--opencl", "rest"])!
         XCTAssertEqual(o.count, 2)
         XCTAssertFalse(o.has(flag: "npm"))
         XCTAssert(o.has(flag: "opencl"))
     }
 
     func testLongFlagOption() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         cmd.define(flagOption: "verbose", shortName: "v", description: "Show more details.")
         cmd.define(flagOption: "useMagic", shortName: "m", description: "Set to use magic.")
 
-        let (_, o0) = cmd.parse(["--useMagic"])!
+        let (_, _, o0) = cmd.parse(arguments: ["prog", "--useMagic"])!
         XCTAssertEqual(o0.count, 2)
         XCTAssertFalse(o0.has(flag: "verbose"))
         XCTAssert(o0.has(flag: "useMagic"))
 
-        let (_, o1) = cmd.parse(["--no-usemagic", "--verbose"])!
+        let (_, _, o1) = cmd.parse(arguments: ["prog", "--no-usemagic", "--verbose"])!
         XCTAssert(o1.has(flag: "verbose"))
         XCTAssert(!o1.has(flag: "usemagic"))
     }
 
     func testLongValueOption() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         let str_validator: (String) throws -> String = { str in
             return str
         }
@@ -126,7 +128,7 @@ class CommandlineTests: XCTestCase {
             validator: str_validator)
         cmd.define(flagOption: "verbose", shortName: "v", description: "")
 
-        let (_, o) = cmd.parse(["--min-user-count=20"])!
+        let (_, _, o) = cmd.parse(arguments: ["prog", "--min-user-count=20"])!
         let i: String? = o.valueOf(option: "min-user-count")
         let a: String? = o.valueOf(option: "max-user-count")
         XCTAssertNotNil(i)
@@ -136,51 +138,53 @@ class CommandlineTests: XCTestCase {
     }
 
     func testDoubleHyphen() {
-        let cmd = Commandline(description: "") { _ in }
-        let (p, _) = cmd.parse(["--", "--no-option", "a/b.txt"])!
+        let cmd = Commandline(description: "")
+        let (_, p, _) = cmd.parse(arguments: ["prog", "--", "--no-option", "a/b.txt"])!
         XCTAssertEqual(p.count, 2)
         XCTAssertEqual(p[p.startIndex], "--no-option")
         XCTAssertEqual(p[p.startIndex + 1], "a/b.txt")
     }
 
     func testSubCommand() {
-        let cmd = Commandline(description: "") { _ in }
-        let subcmd = Commandline(name: "version", description: "") { _ in }
+        let cmd = Commandline(description: "")
+        let subcmd = Commandline(name: "version", description: "")
         subcmd.define(flagOption: "verbose", shortName: "v", description: "")
 
         cmd.add(subCommand: subcmd)
         XCTAssert(cmd.has(subCommand: "version"))
 
-        let (_, o) = cmd.parse(["version", "-v"])!
+        let (cmds, _, o) = cmd.parse(arguments: ["prog", "version", "-v"])!
+        XCTAssertEqual(cmds.count, 1)
+        XCTAssertEqual(cmds[0], "version")
         XCTAssertEqual(o.count, 1)
         XCTAssert(o.has(flag: "verbose"))
     }
 
     func testInvalidSubCommandName() {
-        let cmd = Commandline(description: "") { _ in }
-        let subcmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
+        let subcmd = Commandline(description: "")
         cmd.add(subCommand: subcmd)
         XCTAssertFalse(cmd.has(subCommand: ""))
     }
 
     func testDuplicatedOptionName() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         cmd.define(flagOption: "count", shortName: "c", description: "")
         cmd.define(valueOption: "count", shortName: "n", description: "") { cnt in
             return cnt
         }
         cmd.define(flagOption: "notcount", shortName: "c", description: "")
 
-        let (_, o) = cmd.parse(["--count"])!
+        let (_, _, o) = cmd.parse(arguments: ["prog", "--count"])!
         XCTAssertEqual(o.count, 1)
         XCTAssert(o.has(flag: "count"))
 
-        XCTAssertNil(cmd.parse(["-n", "2"]))
-        XCTAssertNil(cmd.parse(["--notcount"]))
+        XCTAssertNil(cmd.parse(arguments: ["prog", "-n", "2"]))
+        XCTAssertNil(cmd.parse(arguments: ["prog", "--notcount"]))
     }
 
     func testMissingMandatoryOption() {
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         let str_validator: (String) throws -> String = { str in
             return str
         }
@@ -197,11 +201,11 @@ class CommandlineTests: XCTestCase {
             validator: str_validator)
         cmd.define(flagOption: "verbose", shortName: "v", description: "")
 
-        XCTAssertNil(cmd.parse(["-v"]))
-        XCTAssertNil(cmd.parse(["-v", "-a", "20"]))
-        let pr = cmd.parse(["-i", "10"])
+        XCTAssertNil(cmd.parse(arguments: ["prog", "-v"]))
+        XCTAssertNil(cmd.parse(arguments: ["prog", "-v", "-a", "20"]))
+        let pr = cmd.parse(arguments: ["prog", "-i", "10"])
         XCTAssertNotNil(pr)
-        let (_, o) = pr!
+        let (_, _, o) = pr!
         XCTAssertEqual(o.count, 3)
         let i: String = o.valueOf(option: "min-user-count")!
         XCTAssertEqual(i, "10")
@@ -220,14 +224,14 @@ class CommandlineTests: XCTestCase {
             }
             return i
         }
-        let cmd = Commandline(description: "") { _ in }
+        let cmd = Commandline(description: "")
         cmd.define(valueOption: "name", shortName: "n", description: "Name.", validator: name_validator)
         cmd.define(valueOption: "age", shortName: "a", description: "Age.", validator: age_validator)
 
-        XCTAssertNil(cmd.parse(["--name=Ed", "-a", "20"]))
-        XCTAssertNil(cmd.parse(["--name=Edward", "-a", "-10"]))
+        XCTAssertNil(cmd.parse(arguments: ["prog", "--name=Ed", "-a", "20"]))
+        XCTAssertNil(cmd.parse(arguments: ["prog", "--name=Edward", "-a", "-10"]))
 
-        let (_, o) = cmd.parse(["--name=Edward", "-a", "22"])!
+        let (_, _, o) = cmd.parse(arguments: ["prog", "--name=Edward", "-a", "22"])!
         let nm: String? = o.valueOf(option: "name")
         let ag: Int? = o.valueOf(option: "age")
         XCTAssertEqual(nm!, "Edward")

--- a/Tests/FlatUtilTests/FutureTests.swift
+++ b/Tests/FlatUtilTests/FutureTests.swift
@@ -90,7 +90,7 @@ class FutureTests: XCTestCase {
         let h = f.join(g) {
             Future(value: "\($0) == \($1)")
         }
-        var r = h.result(timeout: 1.milliseconds)
+        var r = h.result(timeout: 10.milliseconds)
         XCTAssertNotNil(r.error)
         XCTAssertFalse(f.isCompleted)
         XCTAssert(g.isCompleted)


### PR DESCRIPTION
Instead of executing a closure user should provide, just returns the
parsing result. `execute` is renamed to `parse`.