### PR TITLE
Upgrade to Swift 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,8 @@ language: swift
 matrix:
     include:
         - os: osx
-          osx_image: xcode8.3
+          osx_image: xcode9
           script:
             - swift package update
             - swift build
             - swift test
-        - os: linux
-          dist: trusty
-          sudo: required
-          before_install:
-            - git clone https://github.com/IBM-Swift/Package-Builder.git
-          script:
-            - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -103,6 +103,7 @@ extension Promise {
         guard promises.underestimatedCount > 0 else {
             return res
         }
+        // TODO: Use `dispatch_barrier_sync` instead?
         promises.forEach({ p in
             let future: Future<[T]> = res.f.join(p.f) { (ary, v) in
                 var ar = ary

--- a/Sources/Regexp.swift
+++ b/Sources/Regexp.swift
@@ -41,11 +41,7 @@ public struct Regexp: Equatable, Hashable {
             if rg.length > 0 {
                 ms[0] = String.init(ns.substring(with: results.range))
                 for i in 1 ..< results.numberOfRanges {
-#if os(Linux)
                     rg = results.range(at: i)
-#else
-                    rg = results.rangeAt(i)
-#endif
                     if rg.length < 1 { continue }
                     ms[i] = String.init(ns.substring(with: rg))
                 }

--- a/Tests/FlatUtilTests/Observable+CombiningTests.swift
+++ b/Tests/FlatUtilTests/Observable+CombiningTests.swift
@@ -17,18 +17,18 @@ class ObservableCombiningTests: XCTestCase {
     }
 
     func testZipWithLatest() {
-        let o = Observable.interval(0.1.seconds).map { $0 * 2 + 1 }.take(5)
+        let o = Observable.interval(0.2.seconds).map { $0 * 2 + 1 }.take(5)
 
         expectResults(observable: o.zipWith(latest: Observable<Int>.empty()).map { $0.0 }, satisfy: {
             XCTAssert($0.isEmpty)
         })
 
-        let s = Observable.interval(0.2.seconds).delay(0.1.seconds).map { $0 * 2 }
+        let s = Observable.interval(0.4.seconds).delay(0.1.seconds).map { $0 * 2 }
         expectResults(observable: o.zipWith(latest: s).map { $0.0 }, satisfy: {
-            XCTAssertEqual($0, [5,7,9])
+            XCTAssertEqual($0, [3,5,7,9])
         })
         expectResults(observable: o.zipWith(latest: s).map { $0.1 }, satisfy: {
-            XCTAssertEqual($0, [0,0,2])
+            XCTAssertEqual($0, [0,0,2,2])
         })
     }
 

--- a/Tests/FlatUtilTests/Observable+ConditionalTests.swift
+++ b/Tests/FlatUtilTests/Observable+ConditionalTests.swift
@@ -64,7 +64,7 @@ class ObservableConditionalTests: XCTestCase {
         let s4 = Observable.from(sequence: [0,2,3])
         let s5 = Observable.interval(150.milliseconds).take(5)
         let s6 = Observable<Int>(callback: { o in
-            o.onNext(1)
+            o.onNext(0)
             o.onError(ObservableTestError.init(reason: "noitem"))
         })
 
@@ -87,7 +87,6 @@ class ObservableConditionalTests: XCTestCase {
             XCTAssert($0.isEmpty)
         })
         expectError(observable: o.sequenceEqual(s6), satisfy: { e in
-            XCTAssertNotNil(e)
             XCTAssertEqual((e! as! ObservableTestError).reason, "noitem")
         })
     }

--- a/Tests/FlatUtilTests/Observable+CreationTests.swift
+++ b/Tests/FlatUtilTests/Observable+CreationTests.swift
@@ -89,7 +89,7 @@ extension XCTestCase {
         satisfy: @escaping (Error?) -> Void
     ) {
         let observer = AllItems<O.Item>()
-        let e = expectation(description: "Results")
+        let e = expectation(description: "Error")
         observer.expect { rs in
             satisfy(rs.error)
             e.fulfill()

--- a/Tests/FlatUtilTests/Observable+FilteringTests.swift
+++ b/Tests/FlatUtilTests/Observable+FilteringTests.swift
@@ -81,11 +81,11 @@ class ObservableFilteringTests: XCTestCase {
     }
 
     func testSample() {
-        let s0 = Observable.interval(0.1.seconds)
-        let s1 = Observable.interval(0.2.seconds).delay(0.05.seconds).take(5)
+        let s0 = Observable.interval(0.2.seconds)
+        let s1 = Observable.interval(0.4.seconds).delay(0.05.seconds).take(3)
         let o = s0.sample(s1)
         expectResults(observable: o, satisfy: {
-            XCTAssertEqual($0, [1,3,5,7,9])
+            XCTAssertEqual($0, [0,2,4])
         })
     }
 
@@ -117,10 +117,10 @@ class ObservableFilteringTests: XCTestCase {
     }
 
     func testSkipUntil() {
-        let s = Observable<Int>.just(1).delay(0.1.seconds)
+        let s = Observable<Int>.just(1).delay(0.2.seconds)
         let o = Observable<Int>.interval(0.1.seconds).skip(until: s).take(2)
         expectResults(observable: o, satisfy: {
-            XCTAssertEqual($0, [2,3])
+            XCTAssertEqual($0, [3,4])
         })
     }
 

--- a/Tests/FlatUtilTests/Observable+SubjectTests.swift
+++ b/Tests/FlatUtilTests/Observable+SubjectTests.swift
@@ -1,4 +1,4 @@
- 
+
 import Foundation
 import XCTest
 @testable import FlatUtil

--- a/Tests/FlatUtilTests/Observable+UtilityTests.swift
+++ b/Tests/FlatUtilTests/Observable+UtilityTests.swift
@@ -12,7 +12,6 @@ class ObservableUtilityTests: XCTestCase {
             .map { $0.1 }
             .take(1)
         expectResults(observable: o) {
-            print($0)
             XCTAssert($0[0] > 0.1.seconds)
         }
     }


### PR DESCRIPTION
- Compiled by Swift4.
- Fixed a bug in `Future` and allowed `complete(withResult)` to be called more than once.
- Fixed a bug in `Subject` implementations.
- Adjust time sensitive test cases.